### PR TITLE
migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+* Migrate to null_safety
+
 ## 1.2.0
 
 * Support running on Node.js.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,8 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+  enable-experiment:
+    - non-nullable
 linter:
   rules:
     - avoid_empty_else

--- a/lib/glob.dart
+++ b/lib/glob.dart
@@ -49,25 +49,26 @@ class Glob implements Pattern {
   /// The parsed AST of the glob.
   final AstNode _ast;
 
-  ListTree _listTree;
+  /// This is lazily initialized by calls to [list] or [listSync].
+  ListTree? _listTree;
 
   /// Whether [context]'s current directory is absolute.
   bool get _contextIsAbsolute =>
       _contextIsAbsoluteCache ??= context.isAbsolute(context.current);
 
-  bool _contextIsAbsoluteCache;
+  bool? _contextIsAbsoluteCache;
 
   /// Whether [pattern] could match absolute paths.
   bool get _patternCanMatchAbsolute =>
       _patternCanMatchAbsoluteCache ??= _ast.canMatchAbsolute;
 
-  bool _patternCanMatchAbsoluteCache;
+  bool? _patternCanMatchAbsoluteCache;
 
   /// Whether [pattern] could match relative paths.
   bool get _patternCanMatchRelative =>
       _patternCanMatchRelativeCache ??= _ast.canMatchRelative;
 
-  bool _patternCanMatchRelativeCache;
+  bool? _patternCanMatchRelativeCache;
 
   /// Returns [contents] with characters that are meaningful in globs
   /// backslash-escaped.
@@ -87,7 +88,7 @@ class Glob implements Pattern {
   /// regardless of case. This defaults to `false` when [context] is Windows and
   /// `true` otherwise.
   factory Glob(String pattern,
-      {p.Context context, bool recursive = false, bool caseSensitive}) {
+      {p.Context? context, bool recursive = false, bool? caseSensitive}) {
     context ??= p.context;
     caseSensitive ??= context.style == p.Style.windows ? false : true;
     if (recursive) pattern += '{,/**}';
@@ -108,14 +109,14 @@ class Glob implements Pattern {
   /// [root] defaults to the current working directory.
   ///
   /// [followLinks] works the same as for [Directory.list].
-  Stream<FileSystemEntity> list({String root, bool followLinks = true}) {
+  Stream<FileSystemEntity> list({String? root, bool followLinks = true}) {
     if (context.style != p.style) {
       throw StateError("Can't list glob \"$this\"; it matches "
           '${context.style} paths, but this platform uses ${p.style} paths.');
     }
 
-    _listTree ??= ListTree(_ast);
-    return _listTree.list(root: root, followLinks: followLinks);
+    return (_listTree ??= ListTree(_ast))
+        .list(root: root, followLinks: followLinks);
   }
 
   /// Synchronously lists all [FileSystemEntity]s beneath [root] that match the
@@ -129,21 +130,21 @@ class Glob implements Pattern {
   /// [root] defaults to the current working directory.
   ///
   /// [followLinks] works the same as for [Directory.list].
-  List<FileSystemEntity> listSync({String root, bool followLinks = true}) {
+  List<FileSystemEntity> listSync({String? root, bool followLinks = true}) {
     if (context.style != p.style) {
       throw StateError("Can't list glob \"$this\"; it matches "
           '${context.style} paths, but this platform uses ${p.style} paths.');
     }
 
-    _listTree ??= ListTree(_ast);
-    return _listTree.listSync(root: root, followLinks: followLinks);
+    return (_listTree ??= ListTree(_ast))
+        .listSync(root: root, followLinks: followLinks);
   }
 
   /// Returns whether this glob matches [path].
   bool matches(String path) => matchAsPrefix(path) != null;
 
   @override
-  Match matchAsPrefix(String path, [int start = 0]) {
+  Match? matchAsPrefix(String path, [int start = 0]) {
     // Globs are like anchored RegExps in that they only match entire paths, so
     // if the match starts anywhere after the first character it can't succeed.
     if (start != 0) return null;

--- a/lib/glob.dart
+++ b/lib/glob.dart
@@ -49,7 +49,9 @@ class Glob implements Pattern {
   /// The parsed AST of the glob.
   final AstNode _ast;
 
-  /// This is lazily initialized by calls to [list] or [listSync].
+  /// The underlying object used to implement [list] and [listSync].
+  ///
+  /// This is lazily initialized by calls to those methods.
   ListTree? _listTree;
 
   /// Whether [context]'s current directory is absolute.

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -69,7 +69,7 @@ class Parser {
   /// Tries to parse a [StarNode] or a [DoubleStarNode].
   ///
   /// Returns `null` if there's not one to parse.
-  AstNode _parseStar() {
+  AstNode? _parseStar() {
     if (!_scanner.scan('*')) return null;
     return _scanner.scan('*')
         ? DoubleStarNode(_context, caseSensitive: _caseSensitive)
@@ -79,7 +79,7 @@ class Parser {
   /// Tries to parse an [AnyCharNode].
   ///
   /// Returns `null` if there's not one to parse.
-  AstNode _parseAnyChar() {
+  AstNode? _parseAnyChar() {
     if (!_scanner.scan('?')) return null;
     return AnyCharNode(caseSensitive: _caseSensitive);
   }
@@ -87,7 +87,7 @@ class Parser {
   /// Tries to parse an [RangeNode].
   ///
   /// Returns `null` if there's not one to parse.
-  AstNode _parseRange() {
+  AstNode? _parseRange() {
     if (!_scanner.scan('[')) return null;
     if (_scanner.matches(']')) _scanner.error('unexpected "]".');
     var negated = _scanner.scan('!') || _scanner.scan('^');
@@ -134,7 +134,7 @@ class Parser {
   /// Tries to parse an [OptionsNode].
   ///
   /// Returns `null` if there's not one to parse.
-  AstNode _parseOptions() {
+  AstNode? _parseOptions() {
     if (!_scanner.scan('{')) return null;
     if (_scanner.matches('}')) _scanner.error('unexpected "}".');
 
@@ -157,12 +157,12 @@ class Parser {
     var regExp = RegExp(inOptions ? r'[^*{[?\\}\],()]*' : r'[^*{[?\\}\]()]*');
 
     _scanner.scan(regExp);
-    var buffer = StringBuffer()..write(_scanner.lastMatch[0]);
+    var buffer = StringBuffer()..write(_scanner.lastMatch![0]);
 
     while (_scanner.scan('\\')) {
       buffer.writeCharCode(_scanner.readChar());
       _scanner.scan(regExp);
-      buffer.write(_scanner.lastMatch[0]);
+      buffer.write(_scanner.lastMatch![0]);
     }
 
     for (var char in const [']', '(', ')']) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: glob
-version: 1.2.1-dev
+version: 2.0.0-dev
 
 description: Bash-style filename globbing.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/glob
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.8.0-dev <3.0.0'
 
 dependencies:
   async: '>=1.2.0 <3.0.0'
@@ -19,3 +19,67 @@ dependencies:
 dev_dependencies:
   test: ^1.6.0
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  # Depends on glob ^1.0.0 so we have to override it to get a version solve.
+  analyzer: ^0.39.0
+  async:
+    git:
+      url: git://github.com/dart-lang/async.git
+      ref: null_safety
+  boolean_selector:
+    git:
+      url: git://github.com/dart-lang/boolean_selector.git
+      ref: null_safety
+  charcode:
+    git:
+      url: git://github.com/dart-lang/charcode.git
+      ref: null_safety
+  collection:
+    git:
+      url: git://github.com/dart-lang/collection.git
+      ref: null_safety
+  matcher:
+    git:
+      url: git://github.com/dart-lang/matcher.git
+      ref: null_safety
+  meta:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: null_safety-pkgs
+      path: pkg/meta
+  path:
+    git:
+      url: git://github.com/dart-lang/path.git
+      ref: null_safety
+  source_span:
+    git:
+      url: git://github.com/dart-lang/source_span.git
+      ref: null_safety
+  stack_trace:
+    git:
+      url: git://github.com/dart-lang/stack_trace.git
+      ref: null_safety
+  string_scanner:
+    git:
+      url: git://github.com/dart-lang/string_scanner.git
+      ref: null_safety
+  term_glyph:
+    git:
+      url: git://github.com/dart-lang/term_glyph.git
+      ref: null_safety
+  test_api:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_api
+  test_core:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test_core
+  test:
+    git:
+      url: git://github.com/dart-lang/test.git
+      ref: null_safety
+      path: pkgs/test

--- a/test/glob_test.dart
+++ b/test/glob_test.dart
@@ -63,7 +63,7 @@ void main() {
 
   group('GlobMatch', () {
     var glob = Glob('foo*');
-    var match = glob.matchAsPrefix('foobar');
+    var match = glob.matchAsPrefix('foobar')!;
 
     test('returns the string as input', () {
       expect(match.input, equals('foobar'));

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -314,7 +314,7 @@ void main() {
 }
 
 typedef ListFn = FutureOr<List<String>> Function(String glob,
-    {bool recursive, bool followLinks, bool caseSensitive});
+    {bool recursive, bool followLinks, bool? caseSensitive});
 
 /// Runs [callback] in two groups with two values of [listFn]: one that uses
 /// [Glob.list], one that uses [Glob.listSync].


### PR DESCRIPTION
We likely want to follow up with some breaking changes here, this is just a clean NNBD migration.

Note that there were a _lot_ of assumptions built into the internals of this package about the state of nullable fields, which translates into a lot more `!` than I would like. Specifically the `context` field of `LiteralNode` is unconditionally accessed a lot from public methods/getters.