### PR TITLE
Use a branch of node_io that supports Dart 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.2.0
+  - 2.8.1
 
 # See https://docs.travis-ci.com/user/languages/dart/ for details.
 dart_task:
@@ -11,7 +11,7 @@ dart_task:
 
 jobs:
   include:
-    - dart: 2.2.0
+    - dart: 2.8.1
       dart_task:
         test: -p node
     - dart: dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: glob
-version: 1.2.1-dev
+version: 1.2.1
 
 description: Bash-style filename globbing.
 author: Dart Team <misc@dartlang.org>
@@ -11,7 +11,12 @@ environment:
 dependencies:
   async: '>=1.2.0 <3.0.0'
   collection: ^1.1.0
-  node_io: ^1.0.0
+  # Workaround to support Dart 2.8.
+  node_io:
+    git:
+      url: git://github.com/tekartikdev/node-interop
+      ref: 09209a31962a07f4ab1bf56b4d119fcfb00816f3
+      path: node_io
   path: ^1.3.0
   pedantic: ^1.2.0
   string_scanner: '>=0.1.0 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/glob
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.8.0 <3.0.0'
 
 dependencies:
   async: '>=1.2.0 <3.0.0'


### PR DESCRIPTION
The latest version of `node_io` on package doesn't support Dart 2.8 because of [this breaking change](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#darthtml-1).

This changes glob to depend on pulyaevskiy/node-interop#75. Once that PR is merged, this can be switched back to use the hosted version of `node_io`.