### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/glob.dart
+++ b/lib/glob.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:path/path.dart' as p;
 
 import 'src/ast.dart';


### PR DESCRIPTION
Since Dart 2.1, Future/Stream have been exported from dart:core