### PR TITLE
Use nullable argument to unawaited

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.14.0, dev]
+        sdk: [2.15.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.2
 
 * Drop package:pedantic dependency, use package:lints instead.
+* Update SDK lower bound to `2.15.0`
 
 ## 2.0.1
 

--- a/lib/glob.dart
+++ b/lib/glob.dart
@@ -18,7 +18,7 @@ final _quoteRegExp = RegExp(r'[*{[?\\}\],\-()]');
 ///
 /// A glob matches an entire string as a path. Although the glob pattern uses
 /// POSIX syntax, it can match against POSIX, Windows, or URL paths. The format
-/// it expects paths to use is based on the `context` parameter to [new Glob];
+/// it expects paths to use is based on the `context` parameter to [Glob.new];
 /// it defaults to the current system's syntax.
 ///
 /// Paths are normalized before being matched against a glob, so for example the

--- a/lib/src/list_tree.dart
+++ b/lib/src/list_tree.dart
@@ -345,8 +345,7 @@ class _ListTreeNode {
 
       var resultGroup = StreamGroup<FileSystemEntity>();
       var resultController = StreamController<FileSystemEntity>(sync: true);
-      // TODO: Remove `??` workaround once 2.15 ships (which allows null).
-      unawaited(resultGroup.add(resultController.stream) ?? Future.value());
+      unawaited(resultGroup.add(resultController.stream));
       for (var entity in entities) {
         var basename = p.relative(entity.path, from: dir);
         if (_matches(basename)) resultController.add(entity);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Bash-style filename globbing.
 repository: https://github.com/dart-lang/glob
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   async: ^2.5.0


### PR DESCRIPTION
Bump min SDK to `2.15.0` which allows a null argument. Avoid creating an
unnecessary empty future.

Fix analyzer warning by using constructor tearoff syntax for doc reference.