### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1-dev
+
+* Bump dependencies
+
 ## 2.1.0
 
 * Return empty results instead of throwing when trying to list a path that does

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   async: ^2.5.0
   collection: ^1.15.0
-  file: ^6.0.0
+  file: ^6.1.3
   path: ^1.8.0
   string_scanner: ^1.1.0
 
 dev_dependencies:
   lints: ^1.0.0
-  test: ^1.16.0
+  test: ^1.17.0
   test_descriptor: ^2.0.0


### PR DESCRIPTION
When running `dart pub downgrade` followed by a `dart test`, the tests fail. To solve this, two dependencies need to be upgraded a bit.