### PR TITLE
allow latest file, update to latest dart_flutter_team_lints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+# A CI configuration to auto-publish pub packages.
+
+name: Publish
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+
+jobs:
+  publish:
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    with:
+      sdk: dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.1.2-dev
+## 2.1.2
 
-- Require Dart 2.18
+- Allow `file` version `7.x`.
+- Require Dart 2.19.
 
 ## 2.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: glob
-version: 2.1.2-dev
+version: 2.1.2
 description: A library to perform Bash-style file and directory globbing.
 repository: https://github.com/dart-lang/glob
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
   async: ^2.5.0
   collection: ^1.15.0
-  file: ^6.1.3
+  file: '>=6.1.3 <8.0.0'
   path: ^1.8.0
   string_scanner: ^1.1.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^0.1.0
+  dart_flutter_team_lints: ^1.0.0
   test: ^1.17.0
   test_descriptor: ^2.0.0

--- a/test/list_test.dart
+++ b/test/list_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:async';
 import 'dart:io';
 


### PR DESCRIPTION
This unblocks the dependency cycle so that the latest package:file can work with package:test.

Also preps to release. 